### PR TITLE
Clarify comment on Duo session cleanup in duo_callback

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,7 +134,7 @@ def duo_callback():
             error=f"Duo authentication failed: {e}",
         ), 401
 
-    # Clear interim Duo session data
+    # Clear Duo-specific session state after successful MFA verification
     session.pop("duo_state", None)
     session.pop("duo_username", None)
 


### PR DESCRIPTION
The comment above the Duo session cleanup in `duo_callback` was vague — "interim Duo session data" didn't clearly convey what was being removed or why.

The updated comment — `# Clear Duo-specific session state after successful MFA verification` — is more precise: it names exactly what's being cleaned up (`duo_state` and `duo_username`), and anchors the timing to "after successful MFA verification" rather than the slightly premature "authentication is complete" (since the app-level authenticated session isn't established until the next lines).

Anyone reading the code now gets immediate context on the intent of the `session.pop` calls without needing to trace back through the OAuth flow.

No behavior changes — comment only.

Code reviewed via Codex.
