### PR TITLE
Add descriptive comments to HTML template pages

### DIFF
--- a/templates/auth_result.html
+++ b/templates/auth_result.html
@@ -1,3 +1,6 @@
+<!-- Auth result page: displayed after a successful Duo 2FA verification.
+     Shows the authenticated username, a timestamp, the raw Duo API JSON
+     response, and request metadata for debugging purposes. -->
 {% extends "layout.html" %}
 {% block title %}Auth Result — Duo 2FA Demo{% endblock %}
 {% block content %}

--- a/templates/auth_result.html
+++ b/templates/auth_result.html
@@ -1,6 +1,6 @@
-<!-- Auth result page: displayed after a successful Duo 2FA verification.
-     Shows the authenticated username, a timestamp, the raw Duo API JSON
-     response, and request metadata for debugging purposes. -->
+{# Auth result page: displayed after a successful Duo 2FA verification.
+   Shows the authenticated username, a timestamp, the raw Duo API JSON
+   response, and request metadata for debugging purposes. #}
 {% extends "layout.html" %}
 {% block title %}Auth Result — Duo 2FA Demo{% endblock %}
 {% block content %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,3 +1,6 @@
+<!-- Error page: rendered when authentication fails or an unexpected
+     error occurs during the Duo verification flow. Displays the error
+     message, timestamp, and the originating endpoint for debugging. -->
 {% extends "layout.html" %}
 {% block title %}Error — Duo 2FA Demo{% endblock %}
 {% block content %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,6 +1,6 @@
-<!-- Error page: rendered when authentication fails or an unexpected
-     error occurs during the Duo verification flow. Displays the error
-     message, timestamp, and the originating endpoint for debugging. -->
+{# Error page: rendered when authentication fails or an unexpected
+   error occurs during the Duo verification flow. Displays the error
+   message, timestamp, and the originating endpoint for debugging. #}
 {% extends "layout.html" %}
 {% block title %}Error — Duo 2FA Demo{% endblock %}
 {% block content %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,3 +1,6 @@
+<!-- Base layout template for the Duo 2FA demo app.
+     All pages extend this template via Jinja2 block inheritance.
+     Blocks: title, content, scripts -->
 <!DOCTYPE html>
 <html lang="en-US">
 <head>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,6 +1,6 @@
-<!-- Base layout template for the Duo 2FA demo app.
-     All pages extend this template via Jinja2 block inheritance.
-     Blocks: title, content, scripts -->
+{# Base layout template for the Duo 2FA demo app.
+   All pages extend this template via Jinja2 block inheritance.
+   Blocks: title, content, scripts #}
 <!DOCTYPE html>
 <html lang="en-US">
 <head>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,6 +1,6 @@
-<!-- Login page: collects username/password and submits to /login.
-     Password validation is bypassed in demo/sandbox mode.
-     On submit, redirects to Duo Universal Prompt for 2FA. -->
+{# Login page: collects username/password and submits to /login.
+   Password validation is bypassed in demo/sandbox mode.
+   On submit, redirects to Duo Universal Prompt for 2FA. #}
 {% extends "layout.html" %}
 {% block title %}Sign In — Duo 2FA Demo{% endblock %}
 {% block content %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,3 +1,6 @@
+<!-- Login page: collects username/password and submits to /login.
+     Password validation is bypassed in demo/sandbox mode.
+     On submit, redirects to Duo Universal Prompt for 2FA. -->
 {% extends "layout.html" %}
 {% block title %}Sign In — Duo 2FA Demo{% endblock %}
 {% block content %}


### PR DESCRIPTION
Template files in this Flask/Duo 2FA demo had no top-level documentation, making it harder for developers to orient themselves when jumping between files — especially since the Jinja2 inheritance structure isn't obvious at a glance.

Added a short comment to the top of each of the four template files (`layout.html`, `login.html`, `auth_result.html`, `error.html`) describing the page's purpose and role in the authentication flow. Comments use Jinja2 `{# #}` syntax rather than HTML `<!-- -->` so they are stripped server-side and never reach the browser or page source.

Developers get orientation at a glance; end users see no change. No runtime behavior is affected.

## Testing
- Verified the Flask app renders all pages without errors
- Confirmed `{# #}` comments do not appear in browser page source (unlike `<!-- -->`)

Code reviewed via Codex.
