### PR TITLE
Remove Flask Demo text from footer

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -40,8 +40,6 @@
             <div class="footer-content">
                 <span>Duo Universal Prompt</span>
                 <span class="footer-divider">|</span>
-                <span>Flask Demo</span>
-                <span class="footer-divider">|</span>
                 <span class="api-status">
                     <span class="status-indicator" aria-hidden="true"></span>
                     API Connected


### PR DESCRIPTION
The footer of the login page included a "Flask Demo" label that was leftover from early scaffolding. It didn't describe the app meaningfully and was a bit misleading for a Duo 2FA sandbox.

Removed the `<span>Flask Demo</span>` element and its adjacent `|` divider from `templates/layout.html`. The footer now reads "Duo Universal Prompt | API Connected", which is cleaner and more accurate.

Anyone who looks at the bottom of the page will no longer see the "Flask Demo" label. No functionality is affected — this is a purely cosmetic cleanup.

## Testing

- Verified locally: footer renders "Duo Universal Prompt | API Connected" with no broken layout or orphaned dividers.
- Before/after screenshots confirm the text is gone.

Code reviewed via Codex.
