### PR TITLE
Remove Flask Demo label from footer

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -247,12 +247,12 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
+  gap: 1rem;
   flex-wrap: wrap;
 }
 
 .footer-divider {
-  color: rgba(99, 102, 241, 0.3);
+  color: rgba(99, 102, 241, 0.5);
 }
 
 .api-status {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -39,7 +39,7 @@
         <footer class="app-footer" role="contentinfo">
             <div class="footer-content">
                 <span>Duo Universal Prompt</span>
-                <span class="footer-divider">|</span>
+                <span class="footer-divider" aria-hidden="true">|</span>
                 <span class="api-status">
                     <span class="status-indicator" aria-hidden="true"></span>
                     API Connected

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -40,8 +40,6 @@
             <div class="footer-content">
                 <span>Duo Universal Prompt</span>
                 <span class="footer-divider">|</span>
-                <span>Flask Demo</span>
-                <span class="footer-divider">|</span>
                 <span class="api-status">
                     <span class="status-indicator" aria-hidden="true"></span>
                     API Connected


### PR DESCRIPTION
The footer of the login page included a "Flask Demo" label that was leftover from early scaffolding. It didn't describe the app meaningfully and was a bit misleading for a Duo 2FA sandbox.

Removed the `<span>Flask Demo</span>` element and its adjacent `|` divider from `templates/layout.html`. The footer now reads "Duo Universal Prompt | API Connected", which is cleaner and more accurate. Also added `aria-hidden="true"` to the remaining decorative divider (caught in code review), and nudged the footer gap and divider opacity slightly to keep the two-item layout feeling balanced.

Anyone who looks at the bottom of the page will no longer see the "Flask Demo" label. No functionality is affected — this is a purely cosmetic cleanup.

## Testing

- Verified locally: footer renders "Duo Universal Prompt | API Connected" with no broken layout or orphaned dividers.
- Before/after screenshots confirm the text is gone and footer looks clean.

Code reviewed via Codex.
