### PR TITLE
Remove Flask Demo text from footer

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -39,9 +39,7 @@
         <footer class="app-footer" role="contentinfo">
             <div class="footer-content">
                 <span>Duo Universal Prompt</span>
-                <span class="footer-divider">|</span>
-                <span>Flask Demo</span>
-                <span class="footer-divider">|</span>
+                <span class="footer-divider" aria-hidden="true">|</span>
                 <span class="api-status">
                     <span class="status-indicator" aria-hidden="true"></span>
                     API Connected


### PR DESCRIPTION
The footer showed "Flask Demo" as a label between "Duo Universal Prompt" and the API status indicator. This was leftover placeholder text that doesn't belong in the UI — it reads as noise and slightly undermines the professional feel of the demo app.

Removed the `<span>Flask Demo</span>` element and the orphaned `|` divider that followed it from `templates/layout.html`. Also added `aria-hidden="true"` to the remaining decorative divider since it's purely visual and shouldn't be read aloud by screen readers.

The footer now reads "Duo Universal Prompt | ● API Connected" — cleaner and more purposeful. No functional behavior changes.

## Testing

- Verified visually in the browser with before/after screenshots — the text is gone and the layout remains balanced.
- Confirmed no other occurrences of "Flask Demo" exist in the codebase.

Code reviewed via Codex.
