### PR TITLE
Remove Flask Demo label from footer

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -40,8 +40,6 @@
             <div class="footer-content">
                 <span>Duo Universal Prompt</span>
                 <span class="footer-divider">|</span>
-                <span>Flask Demo</span>
-                <span class="footer-divider">|</span>
                 <span class="api-status">
                     <span class="status-indicator" aria-hidden="true"></span>
                     API Connected


### PR DESCRIPTION
The footer had a "Flask Demo" label that leaked implementation detail — the fact that the backend is Flask — to anyone viewing the page. This is noise that doesn't help users or testers and doesn't belong on a page that's otherwise branded as a Duo 2FA sandbox.

Removed the `<span>Flask Demo</span>` element and the preceding `|` divider from `templates/layout.html`. The footer now reads "Duo Universal Prompt | API Connected" instead of "Duo Universal Prompt | Flask Demo | API Connected". No CSS changes were needed; the footer was already centered via flexbox `justify-content: center`.

The footer is visually cleaner. Anyone using or demoing the app will see one less piece of internal plumbing in the UI.

## Testing
- Verified visually by running the app locally and confirming the footer no longer shows "Flask Demo"
- Before/after screenshots confirm correct rendering
- No other files reference "Flask Demo" — confirmed via codebase search

Code reviewed via Codex.
