### PR TITLE
Remove Flask Demo text from footer

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -40,8 +40,6 @@
             <div class="footer-content">
                 <span>Duo Universal Prompt</span>
                 <span class="footer-divider">|</span>
-                <span>Flask Demo</span>
-                <span class="footer-divider">|</span>
                 <span class="api-status">
                     <span class="status-indicator" aria-hidden="true"></span>
                     API Connected


### PR DESCRIPTION
The footer of the Duo 2FA app had a "Flask Demo" label that was leftover from early development scaffolding. It served no purpose for end users or testers and was noise in what is otherwise a clean, polished UI.

Removed the "Flask Demo" `<span>` and its adjacent divider from the footer in `templates/layout.html`. The footer now reads "Duo Universal Prompt | API Connected" — concise and relevant.

Visitors to the app will no longer see the generic "Flask Demo" label in the footer. The remaining footer items and layout are unaffected.

## Testing

- Loaded the app locally and confirmed the footer no longer shows "Flask Demo"
- Before: `Duo Universal Prompt | Flask Demo | API Connected`
- After: `Duo Universal Prompt | API Connected`

Code reviewed via Codex.
