### PR TITLE
Remove Flask Demo label from footer

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -40,8 +40,6 @@
             <div class="footer-content">
                 <span>Duo Universal Prompt</span>
                 <span class="footer-divider">|</span>
-                <span>Flask Demo</span>
-                <span class="footer-divider">|</span>
                 <span class="api-status">
                     <span class="status-indicator" aria-hidden="true"></span>
                     API Connected


### PR DESCRIPTION
The footer of the duo-auth app displayed a "Flask Demo" label that was a leftover from early development scaffolding. It added no value for users or reviewers of the sandbox and gave the impression it was a generic Flask template rather than a Duo-specific tool.

Removed the `<span>Flask Demo</span>` element and its preceding `|` divider from the shared `layout.html` footer. The footer now reads "Duo Universal Prompt | • API Connected" — clean and accurate.

No one reading the footer was getting useful information from "Flask Demo". The remaining footer items (Duo Universal Prompt label and API status indicator) are meaningful context worth keeping.

## Testing

- Verified the text appears correctly removed in the browser footer
- Confirmed `.footer-divider` CSS is still active on the remaining divider — no dead styles introduced
- Before: `Duo Universal Prompt | Flask Demo | • API Connected`
- After: `Duo Universal Prompt | • API Connected`

Code reviewed via Codex.
