### PR TITLE
Change background to bright yellow gradient

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -13,7 +13,7 @@
   /* Dark Theme Colors */
   --bg-primary: #1f0d00;
   --bg-secondary: #150900;
-  --card-bg: rgba(20, 26, 39, 0.7);
+  --card-bg: rgba(20, 26, 39, 0.82);
   --card-border: rgba(251, 146, 60, 0.3);
 
   /* Accent Colors */
@@ -38,7 +38,7 @@
   --gradient-primary: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
   --gradient-cyan: linear-gradient(135deg, #06b6d4 0%, #0891b2 100%);
   --gradient-success: linear-gradient(135deg, #10b981 0%, #059669 100%);
-  --gradient-bg: linear-gradient(135deg, #c2410c 0%, #ea580c 45%, #fb923c 100%);
+  --gradient-bg: linear-gradient(135deg, #b83a0a 0%, #d95508 45%, #f58428 100%);
 
   /* Shadows */
   --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
@@ -106,8 +106,8 @@ body {
 
 /* === Sandbox Banner === */
 .sandbox-banner {
-  background: linear-gradient(90deg, rgba(139, 92, 246, 0.15) 0%, rgba(99, 102, 241, 0.15) 100%);
-  border-bottom: 1px solid rgba(139, 92, 246, 0.3);
+  background: linear-gradient(90deg, rgba(180, 60, 12, 0.35) 0%, rgba(220, 90, 20, 0.25) 100%);
+  border-bottom: 1px solid rgba(251, 146, 60, 0.4);
   padding: 0.5rem 0;
   backdrop-filter: blur(12px);
 }
@@ -132,8 +132,8 @@ body {
 }
 
 .sandbox-badge {
-  background: rgba(139, 92, 246, 0.2);
-  color: #c4b5fd;
+  background: rgba(251, 146, 60, 0.2);
+  color: #fdba74;
   padding: 0.125rem 0.625rem;
   border-radius: 0.375rem;
   font-size: 0.6875rem;
@@ -141,7 +141,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.05em;
   font-family: var(--font-mono);
-  border: 1px solid rgba(139, 92, 246, 0.4);
+  border: 1px solid rgba(251, 146, 60, 0.5);
 }
 
 /* === Layout === */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -11,10 +11,10 @@
 
 :root {
   /* Dark Theme Colors */
-  --bg-primary: #1f0d00;
-  --bg-secondary: #150900;
+  --bg-primary: #1a1600;
+  --bg-secondary: #120f00;
   --card-bg: rgba(20, 26, 39, 0.82);
-  --card-border: rgba(251, 146, 60, 0.3);
+  --card-border: rgba(253, 224, 71, 0.3);
 
   /* Accent Colors */
   --accent-primary: #6366f1;
@@ -38,13 +38,13 @@
   --gradient-primary: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
   --gradient-cyan: linear-gradient(135deg, #06b6d4 0%, #0891b2 100%);
   --gradient-success: linear-gradient(135deg, #10b981 0%, #059669 100%);
-  --gradient-bg: linear-gradient(135deg, #b83a0a 0%, #d95508 45%, #f58428 100%);
+  --gradient-bg: linear-gradient(135deg, #ca8a04 0%, #eab308 45%, #fde047 100%);
 
   /* Shadows */
   --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-  --shadow-glow: 0 0 40px rgba(251, 146, 60, 0.4);
+  --shadow-glow: 0 0 40px rgba(234, 179, 8, 0.4);
 }
 
 body {
@@ -53,17 +53,17 @@ body {
   background-image:
     repeating-linear-gradient(
       90deg,
-      rgba(255, 200, 100, 0.08) 0px,
+      rgba(253, 224, 71, 0.08) 0px,
       transparent 1px,
       transparent 39px,
-      rgba(255, 200, 100, 0.08) 40px
+      rgba(253, 224, 71, 0.08) 40px
     ),
     repeating-linear-gradient(
       0deg,
-      rgba(255, 200, 100, 0.08) 0px,
+      rgba(253, 224, 71, 0.08) 0px,
       transparent 1px,
       transparent 39px,
-      rgba(255, 200, 100, 0.08) 40px
+      rgba(253, 224, 71, 0.08) 40px
     ),
     var(--gradient-bg);
   color: var(--text-primary);
@@ -106,8 +106,8 @@ body {
 
 /* === Sandbox Banner === */
 .sandbox-banner {
-  background: linear-gradient(90deg, rgba(180, 60, 12, 0.35) 0%, rgba(220, 90, 20, 0.25) 100%);
-  border-bottom: 1px solid rgba(251, 146, 60, 0.4);
+  background: linear-gradient(90deg, rgba(161, 130, 0, 0.35) 0%, rgba(202, 138, 4, 0.25) 100%);
+  border-bottom: 1px solid rgba(253, 224, 71, 0.4);
   padding: 0.5rem 0;
   backdrop-filter: blur(12px);
 }
@@ -132,8 +132,8 @@ body {
 }
 
 .sandbox-badge {
-  background: rgba(251, 146, 60, 0.2);
-  color: #fdba74;
+  background: rgba(253, 224, 71, 0.2);
+  color: #fde047;
   padding: 0.125rem 0.625rem;
   border-radius: 0.375rem;
   font-size: 0.6875rem;
@@ -141,7 +141,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.05em;
   font-family: var(--font-mono);
-  border: 1px solid rgba(251, 146, 60, 0.5);
+  border: 1px solid rgba(253, 224, 71, 0.5);
 }
 
 /* === Layout === */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -14,7 +14,7 @@
   --bg-primary: #1f0d00;
   --bg-secondary: #150900;
   --card-bg: rgba(20, 26, 39, 0.7);
-  --card-border: rgba(99, 102, 241, 0.25);
+  --card-border: rgba(251, 146, 60, 0.3);
 
   /* Accent Colors */
   --accent-primary: #6366f1;
@@ -44,28 +44,28 @@
   --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-  --shadow-glow: 0 0 40px rgba(99, 102, 241, 0.4);
+  --shadow-glow: 0 0 40px rgba(251, 146, 60, 0.4);
 }
 
 body {
   font-family: var(--font-sans);
   background: var(--bg-primary);
   background-image:
-    var(--gradient-bg),
     repeating-linear-gradient(
       90deg,
-      rgba(255, 200, 100, 0.06) 0px,
+      rgba(255, 200, 100, 0.08) 0px,
       transparent 1px,
       transparent 39px,
-      rgba(255, 200, 100, 0.06) 40px
+      rgba(255, 200, 100, 0.08) 40px
     ),
     repeating-linear-gradient(
       0deg,
-      rgba(255, 200, 100, 0.06) 0px,
+      rgba(255, 200, 100, 0.08) 0px,
       transparent 1px,
       transparent 39px,
-      rgba(255, 200, 100, 0.06) 40px
-    );
+      rgba(255, 200, 100, 0.08) 40px
+    ),
+    var(--gradient-bg);
   color: var(--text-primary);
   min-height: 100vh;
   line-height: 1.6;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -11,8 +11,8 @@
 
 :root {
   /* Dark Theme Colors */
-  --bg-primary: #0a0e1a;
-  --bg-secondary: #0f1419;
+  --bg-primary: #1f0d00;
+  --bg-secondary: #150900;
   --card-bg: rgba(20, 26, 39, 0.7);
   --card-border: rgba(99, 102, 241, 0.25);
 
@@ -38,7 +38,7 @@
   --gradient-primary: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
   --gradient-cyan: linear-gradient(135deg, #06b6d4 0%, #0891b2 100%);
   --gradient-success: linear-gradient(135deg, #10b981 0%, #059669 100%);
-  --gradient-bg: radial-gradient(ellipse at top, rgba(99, 102, 241, 0.12) 0%, transparent 60%);
+  --gradient-bg: linear-gradient(135deg, #c2410c 0%, #ea580c 45%, #fb923c 100%);
 
   /* Shadows */
   --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
@@ -54,17 +54,17 @@ body {
     var(--gradient-bg),
     repeating-linear-gradient(
       90deg,
-      rgba(99, 102, 241, 0.05) 0px,
+      rgba(255, 200, 100, 0.06) 0px,
       transparent 1px,
       transparent 39px,
-      rgba(99, 102, 241, 0.05) 40px
+      rgba(255, 200, 100, 0.06) 40px
     ),
     repeating-linear-gradient(
       0deg,
-      rgba(99, 102, 241, 0.05) 0px,
+      rgba(255, 200, 100, 0.06) 0px,
       transparent 1px,
       transparent 39px,
-      rgba(99, 102, 241, 0.05) 40px
+      rgba(255, 200, 100, 0.06) 40px
     );
   color: var(--text-primary);
   min-height: 100vh;


### PR DESCRIPTION
The duo-auth sandbox login page used a flat dark navy background (#0a0e1a) that made the UI feel generic and hard to visually distinguish from other dev tools. Designers reviewing the app wanted a more expressive, high-energy background to make the testing environment feel intentional and distinct from production.

The background is now a bright yellow gradient (gold through amber to bright yellow at 135°), applied as the base layer in `background-image` so a warm grid texture renders on top and adds depth. All warm accent tokens were updated in lock-step — card border, shadow glow, sandbox banner, and the Demo Mode badge now use yellow-family values instead of the previous purple/indigo palette, keeping the color story coherent across the page.

The login page now has a vivid yellow gradient backdrop behind the dark semi-transparent card. The sandbox banner at the top shifts from purple to warm gold tones, the "DEMO MODE" badge matches, and the card itself sits with improved opacity (0.82) so the form content reads clearly against the bright background. Users hitting the sandbox URL will immediately see a distinct look that reads "dev environment" at a glance.

## Testing

Load `http://localhost:8080` and verify the background is a bright yellow gradient. Check that the sandbox banner, Demo Mode badge, and card border all use yellow/gold tones. Verify form text, labels, and placeholder text remain legible. Resize to mobile widths to confirm the gradient covers the viewport correctly.

---

Requested by omara@cisco.com

Code reviewed via Codex.

## Visual Changes

### Page Background

| Before | After |
|--------|-------|
| ![Before](https://github.com/ojaber/duo-auth-sandbox/releases/download/sprintpilot-screenshots/5e172dc9-before-page-background.png) | ![After](https://github.com/ojaber/duo-auth-sandbox/releases/download/sprintpilot-screenshots/5e172dc9-after-page-background.png) |
