### PR TITLE
Style 'Continue to Duo 2FA' button shiny silver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 *.pyc
 .claude/
 .playwright-mcp/
+
+# SprintPilot session data
+.sprintpilot/

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -490,14 +490,18 @@ input[aria-invalid="true"]:focus {
   transform: none !important;
 }
 
-/* === Continue to 2FA Button (Pink) === */
+/* === Continue to 2FA Button (Shiny Silver) === */
 #submit-btn {
-  background: linear-gradient(135deg, #ec4899 0%, #f43f5e 100%);
-  box-shadow: 0 4px 12px rgba(236, 72, 153, 0.35);
+  background: linear-gradient(135deg, #e8e8e8 0%, #a8a8a8 40%, #f0f0f0 60%, #b0b0b0 100%);
+  box-shadow: 0 4px 12px rgba(160, 160, 160, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  color: #1a1a1a;
+  border: 1px solid #999;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 #submit-btn:hover {
-  box-shadow: 0 8px 20px rgba(236, 72, 153, 0.5), 0 0 40px rgba(236, 72, 153, 0.3);
+  background: linear-gradient(135deg, #f0f0f0 0%, #c0c0c0 40%, #ffffff 60%, #c8c8c8 100%);
+  box-shadow: 0 8px 20px rgba(160, 160, 160, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
 /* === Loading State === */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -490,6 +490,16 @@ input[aria-invalid="true"]:focus {
   transform: none !important;
 }
 
+/* === Continue to 2FA Button (Pink) === */
+#submit-btn {
+  background: linear-gradient(135deg, #ec4899 0%, #f43f5e 100%);
+  box-shadow: 0 4px 12px rgba(236, 72, 153, 0.35);
+}
+
+#submit-btn:hover {
+  box-shadow: 0 8px 20px rgba(236, 72, 153, 0.5), 0 0 40px rgba(236, 72, 153, 0.3);
+}
+
 /* === Loading State === */
 .btn-primary.loading {
   pointer-events: none;


### PR DESCRIPTION
The "Continue to Duo 2FA" button on the login page was using the default indigo/purple gradient from the global `.btn-primary` style, which didn't stand out visually as the primary call-to-action on the page. The design team wanted a distinct treatment to make the button more prominent and better match the intended brand direction.

The button now renders with a shiny silver metallic gradient — light silver at the top, deeper mid-tone in the centre, with a bright highlight at 60%, and a subtle inset top-edge glow to sell the depth effect. An `#999` border and a soft white text-shadow keep the dark label legible against the light surface. The hover state lifts the gradient slightly brighter and strengthens the shadow, giving clear interactive feedback without animation overhead. All changes are scoped to `#submit-btn` so no other button styling is affected.

Users visiting the login page will see a shiny silver button instead of the previous purple one. The button text remains dark (`#1a1a1a`) for contrast, and hover behaviour is visually distinct and consistent with the rest of the UI's interaction model.

## Testing

Verified visually in Playwright against a running local instance — before/after screenshots confirm the colour change renders correctly. Check the button on the login page at `/`, confirm it is silver with legible dark text, and hover over it to verify the brightened gradient and shadow appear.

Requested by omara@cisco.com

Code reviewed via Codex.

## Visual Changes

### R3

| Before | After |
|--------|-------|
| ![Before](https://github.com/ojaber/duo-auth-sandbox/releases/download/sprintpilot-screenshots/7ef71300-before-r3.png) | ![After](https://github.com/ojaber/duo-auth-sandbox/releases/download/sprintpilot-screenshots/7ef71300-after-r3.png) |
