### PR TITLE
Apply Barbie-themed pink background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 *.pyc
 .claude/
 .playwright-mcp/
+
+# SprintPilot session data
+.sprintpilot/

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -11,10 +11,10 @@
 
 :root {
   /* Barbie Pink Theme Colors */
-  --bg-primary: #1a0020;
-  --bg-secondary: #220028;
-  --card-bg: rgba(50, 5, 45, 0.78);
-  --card-border: rgba(255, 105, 180, 0.4);
+  --bg-primary: #C2005A;
+  --bg-secondary: #D40065;
+  --card-bg: rgba(18, 0, 12, 0.88);
+  --card-border: rgba(255, 182, 224, 0.45);
 
   /* Barbie Accent Colors */
   --accent-primary: #FF1493;
@@ -38,7 +38,7 @@
   --gradient-primary: linear-gradient(135deg, #FF1493 0%, #FF69B4 100%);
   --gradient-cyan: linear-gradient(135deg, #FF85C1 0%, #FF1493 100%);
   --gradient-success: linear-gradient(135deg, #FF85C2 0%, #E91E8C 100%);
-  --gradient-bg: radial-gradient(ellipse at top, rgba(255, 20, 147, 0.22) 0%, transparent 60%);
+  --gradient-bg: radial-gradient(ellipse at top, rgba(255, 255, 255, 0.18) 0%, transparent 55%);
 
   /* Shadows */
   --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
@@ -52,20 +52,21 @@ body {
   background: var(--bg-primary);
   background-image:
     var(--gradient-bg),
-    radial-gradient(ellipse at bottom right, rgba(233, 30, 140, 0.12) 0%, transparent 55%),
+    radial-gradient(ellipse at bottom right, rgba(255, 20, 147, 0.35) 0%, transparent 55%),
+    radial-gradient(ellipse at top left, rgba(255, 105, 180, 0.25) 0%, transparent 50%),
     repeating-linear-gradient(
       90deg,
-      rgba(255, 20, 147, 0.06) 0px,
+      rgba(255, 255, 255, 0.05) 0px,
       transparent 1px,
       transparent 39px,
-      rgba(255, 20, 147, 0.06) 40px
+      rgba(255, 255, 255, 0.05) 40px
     ),
     repeating-linear-gradient(
       0deg,
-      rgba(255, 20, 147, 0.06) 0px,
+      rgba(255, 255, 255, 0.05) 0px,
       transparent 1px,
       transparent 39px,
-      rgba(255, 20, 147, 0.06) 40px
+      rgba(255, 255, 255, 0.05) 40px
     );
   color: var(--text-primary);
   min-height: 100vh;
@@ -155,8 +156,8 @@ body {
 .app-header {
   padding: 1.5rem 2rem;
   backdrop-filter: blur(12px);
-  background: rgba(30, 5, 25, 0.55);
-  border-bottom: 1px solid rgba(255, 20, 147, 0.2);
+  background: rgba(100, 0, 50, 0.55);
+  border-bottom: 1px solid rgba(255, 182, 224, 0.3);
   position: sticky;
   top: 0;
   z-index: 100;
@@ -239,8 +240,8 @@ body {
   text-align: center;
   font-size: 0.8125rem;
   color: var(--text-muted);
-  border-top: 1px solid rgba(255, 20, 147, 0.12);
-  background: rgba(30, 5, 25, 0.35);
+  border-top: 1px solid rgba(255, 182, 224, 0.2);
+  background: rgba(100, 0, 50, 0.45);
   font-family: var(--font-mono);
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,5 +1,5 @@
 /* ========================================
-   Duo 2FA Testing Lab - Dev Tool Dark Theme
+   Duo 2FA Testing Lab - Barbie Pink Theme
    ======================================== */
 
 /* === CSS Reset & Base === */
@@ -10,41 +10,41 @@
 }
 
 :root {
-  /* Dark Theme Colors */
-  --bg-primary: #0a0e1a;
-  --bg-secondary: #0f1419;
-  --card-bg: rgba(20, 26, 39, 0.7);
-  --card-border: rgba(99, 102, 241, 0.25);
+  /* Barbie Pink Theme Colors */
+  --bg-primary: #1a0020;
+  --bg-secondary: #220028;
+  --card-bg: rgba(50, 5, 45, 0.78);
+  --card-border: rgba(255, 105, 180, 0.4);
 
-  /* Accent Colors */
-  --accent-primary: #6366f1;
-  --accent-secondary: #8b5cf6;
-  --accent-cyan: #06b6d4;
-  --accent-success: #10b981;
-  --accent-warning: #f59e0b;
+  /* Barbie Accent Colors */
+  --accent-primary: #FF1493;
+  --accent-secondary: #FF69B4;
+  --accent-cyan: #FF85C1;
+  --accent-success: #FF69B4;
+  --accent-warning: #FFD700;
   --accent-error: #ef4444;
 
   /* Text Colors */
-  --text-primary: #f8fafc;
-  --text-secondary: #94a3b8;
-  --text-muted: #64748b;
-  --text-code: #e0e7ff;
+  --text-primary: #fff0f8;
+  --text-secondary: #FFB6E0;
+  --text-muted: #D490B8;
+  --text-code: #FFD6EE;
 
   /* Fonts */
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
 
   /* Gradients */
-  --gradient-primary: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
-  --gradient-cyan: linear-gradient(135deg, #06b6d4 0%, #0891b2 100%);
-  --gradient-success: linear-gradient(135deg, #10b981 0%, #059669 100%);
-  --gradient-bg: radial-gradient(ellipse at top, rgba(99, 102, 241, 0.12) 0%, transparent 60%);
+  --gradient-primary: linear-gradient(135deg, #FF1493 0%, #FF69B4 100%);
+  --gradient-cyan: linear-gradient(135deg, #FF85C1 0%, #FF1493 100%);
+  --gradient-success: linear-gradient(135deg, #FF85C2 0%, #E91E8C 100%);
+  --gradient-bg: radial-gradient(ellipse at top, rgba(255, 20, 147, 0.22) 0%, transparent 60%);
 
   /* Shadows */
   --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
-  --shadow-glow: 0 0 40px rgba(99, 102, 241, 0.4);
+  --shadow-glow: 0 0 40px rgba(255, 20, 147, 0.55);
 }
 
 body {
@@ -52,19 +52,20 @@ body {
   background: var(--bg-primary);
   background-image:
     var(--gradient-bg),
+    radial-gradient(ellipse at bottom right, rgba(233, 30, 140, 0.12) 0%, transparent 55%),
     repeating-linear-gradient(
       90deg,
-      rgba(99, 102, 241, 0.05) 0px,
+      rgba(255, 20, 147, 0.06) 0px,
       transparent 1px,
       transparent 39px,
-      rgba(99, 102, 241, 0.05) 40px
+      rgba(255, 20, 147, 0.06) 40px
     ),
     repeating-linear-gradient(
       0deg,
-      rgba(99, 102, 241, 0.05) 0px,
+      rgba(255, 20, 147, 0.06) 0px,
       transparent 1px,
       transparent 39px,
-      rgba(99, 102, 241, 0.05) 40px
+      rgba(255, 20, 147, 0.06) 40px
     );
   color: var(--text-primary);
   min-height: 100vh;
@@ -106,8 +107,8 @@ body {
 
 /* === Sandbox Banner === */
 .sandbox-banner {
-  background: linear-gradient(90deg, rgba(139, 92, 246, 0.15) 0%, rgba(99, 102, 241, 0.15) 100%);
-  border-bottom: 1px solid rgba(139, 92, 246, 0.3);
+  background: linear-gradient(90deg, rgba(255, 20, 147, 0.18) 0%, rgba(255, 105, 180, 0.18) 100%);
+  border-bottom: 1px solid rgba(255, 105, 180, 0.4);
   padding: 0.5rem 0;
   backdrop-filter: blur(12px);
 }
@@ -123,7 +124,7 @@ body {
 
 .sandbox-icon {
   font-size: 1rem;
-  filter: drop-shadow(0 0 8px rgba(139, 92, 246, 0.6));
+  filter: drop-shadow(0 0 8px rgba(255, 20, 147, 0.7));
 }
 
 .sandbox-text {
@@ -132,8 +133,8 @@ body {
 }
 
 .sandbox-badge {
-  background: rgba(139, 92, 246, 0.2);
-  color: #c4b5fd;
+  background: rgba(255, 20, 147, 0.22);
+  color: #FFB6E0;
   padding: 0.125rem 0.625rem;
   border-radius: 0.375rem;
   font-size: 0.6875rem;
@@ -141,7 +142,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.05em;
   font-family: var(--font-mono);
-  border: 1px solid rgba(139, 92, 246, 0.4);
+  border: 1px solid rgba(255, 105, 180, 0.5);
 }
 
 /* === Layout === */
@@ -154,8 +155,8 @@ body {
 .app-header {
   padding: 1.5rem 2rem;
   backdrop-filter: blur(12px);
-  background: rgba(15, 23, 42, 0.5);
-  border-bottom: 1px solid rgba(99, 102, 241, 0.15);
+  background: rgba(30, 5, 25, 0.55);
+  border-bottom: 1px solid rgba(255, 20, 147, 0.2);
   position: sticky;
   top: 0;
   z-index: 100;
@@ -198,7 +199,7 @@ body {
 }
 
 .version-badge {
-  background: rgba(99, 102, 241, 0.15);
+  background: rgba(255, 20, 147, 0.15);
   color: var(--text-muted);
   padding: 0.125rem 0.5rem;
   border-radius: 0.375rem;
@@ -206,7 +207,7 @@ body {
   font-weight: 600;
   font-family: var(--font-mono);
   letter-spacing: 0.02em;
-  border: 1px solid rgba(99, 102, 241, 0.25);
+  border: 1px solid rgba(255, 105, 180, 0.3);
 }
 
 .dev-badge {
@@ -238,8 +239,8 @@ body {
   text-align: center;
   font-size: 0.8125rem;
   color: var(--text-muted);
-  border-top: 1px solid rgba(99, 102, 241, 0.08);
-  background: rgba(15, 23, 42, 0.3);
+  border-top: 1px solid rgba(255, 20, 147, 0.12);
+  background: rgba(30, 5, 25, 0.35);
   font-family: var(--font-mono);
 }
 
@@ -252,7 +253,7 @@ body {
 }
 
 .footer-divider {
-  color: rgba(99, 102, 241, 0.3);
+  color: rgba(255, 105, 180, 0.35);
 }
 
 .api-status {
@@ -280,7 +281,7 @@ body {
   padding: 2.5rem;
   width: 100%;
   max-width: 580px;
-  box-shadow: var(--shadow-lg), inset 0 1px 0 0 rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-lg), inset 0 1px 0 0 rgba(255, 255, 255, 0.06);
   animation: fadeInUp 0.6s cubic-bezier(0.16, 1, 0.3, 1);
   position: relative;
   overflow: hidden;
@@ -293,7 +294,7 @@ body {
   left: 0;
   right: 0;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(99, 102, 241, 0.5), transparent);
+  background: linear-gradient(90deg, transparent, rgba(255, 20, 147, 0.6), transparent);
 }
 
 @keyframes fadeInUp {
@@ -353,8 +354,8 @@ input[type="password"] {
   font-size: 1rem;
   font-family: inherit;
   color: var(--text-primary);
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(30, 5, 25, 0.65);
+  border: 1px solid rgba(255, 105, 180, 0.3);
   border-radius: 0.75rem;
   outline: none;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -362,17 +363,17 @@ input[type="password"] {
 
 input[type="text"]:hover,
 input[type="password"]:hover {
-  border-color: rgba(6, 182, 212, 0.4);
-  background: rgba(15, 23, 42, 0.8);
+  border-color: rgba(255, 105, 180, 0.55);
+  background: rgba(30, 5, 25, 0.8);
 }
 
 input[type="text"]:focus,
 input[type="password"]:focus {
   border-color: var(--accent-cyan);
-  background: rgba(15, 23, 42, 0.9);
-  box-shadow: 0 0 0 3px rgba(6, 182, 212, 0.15),
+  background: rgba(30, 5, 25, 0.9);
+  box-shadow: 0 0 0 3px rgba(255, 133, 193, 0.18),
               0 4px 12px rgba(0, 0, 0, 0.2),
-              inset 0 1px 2px rgba(6, 182, 212, 0.1);
+              inset 0 1px 2px rgba(255, 133, 193, 0.1);
   transform: translateY(-1px);
 }
 
@@ -430,7 +431,7 @@ input[aria-invalid="true"]:focus {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0%, transparent 50%);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12) 0%, transparent 50%);
   opacity: 0;
   transition: opacity 0.3s;
 }
@@ -442,13 +443,13 @@ input[aria-invalid="true"]:focus {
 .btn-primary {
   background: var(--gradient-primary);
   color: white;
-  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
+  box-shadow: 0 4px 12px rgba(255, 20, 147, 0.35);
   width: 100%;
 }
 
 .btn-primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(99, 102, 241, 0.4), var(--shadow-glow);
+  box-shadow: 0 8px 20px rgba(255, 20, 147, 0.5), var(--shadow-glow);
 }
 
 .btn-primary:active {
@@ -456,29 +457,29 @@ input[aria-invalid="true"]:focus {
 }
 
 .btn-secondary {
-  background: rgba(148, 163, 184, 0.1);
+  background: rgba(255, 105, 180, 0.12);
   color: var(--text-secondary);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(255, 105, 180, 0.25);
 }
 
 .btn-secondary:hover {
-  background: rgba(148, 163, 184, 0.15);
+  background: rgba(255, 105, 180, 0.2);
   color: var(--text-primary);
-  border-color: rgba(148, 163, 184, 0.3);
+  border-color: rgba(255, 105, 180, 0.4);
   transform: translateY(-1px);
 }
 
 .btn-outline {
   background: transparent;
   color: var(--text-secondary);
-  border: 1px solid rgba(148, 163, 184, 0.3);
+  border: 1px solid rgba(255, 105, 180, 0.35);
   text-decoration: none;
 }
 
 .btn-outline:hover {
-  background: rgba(148, 163, 184, 0.1);
+  background: rgba(255, 105, 180, 0.1);
   color: var(--text-primary);
-  border-color: rgba(148, 163, 184, 0.5);
+  border-color: rgba(255, 105, 180, 0.55);
   transform: translateY(-1px);
 }
 
@@ -540,8 +541,8 @@ input[aria-invalid="true"]:focus {
 /* === Info Note Box === */
 .info-note {
   padding: 1rem 1.25rem;
-  background: rgba(6, 182, 212, 0.05);
-  border: 1px solid rgba(6, 182, 212, 0.15);
+  background: rgba(255, 20, 147, 0.06);
+  border: 1px solid rgba(255, 105, 180, 0.2);
   border-radius: 0.75rem;
   font-size: 0.875rem;
   color: var(--text-secondary);
@@ -567,7 +568,7 @@ input[aria-invalid="true"]:focus {
   align-items: center;
   justify-content: center;
   font-size: 2.5rem;
-  box-shadow: 0 0 40px rgba(16, 185, 129, 0.4);
+  box-shadow: 0 0 40px rgba(255, 20, 147, 0.45);
   animation: successPulse 0.6s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -612,15 +613,15 @@ input[aria-invalid="true"]:focus {
   align-items: center;
   gap: 1rem;
   padding: 0.75rem 1rem;
-  background: rgba(15, 23, 42, 0.4);
-  border: 1px solid rgba(99, 102, 241, 0.1);
+  background: rgba(30, 5, 25, 0.45);
+  border: 1px solid rgba(255, 20, 147, 0.12);
   border-radius: 0.5rem;
   transition: all 0.2s;
 }
 
 .kv-item:hover {
-  background: rgba(15, 23, 42, 0.6);
-  border-color: rgba(99, 102, 241, 0.2);
+  background: rgba(30, 5, 25, 0.65);
+  border-color: rgba(255, 20, 147, 0.25);
 }
 
 .kv-key {
@@ -658,9 +659,9 @@ input[aria-invalid="true"]:focus {
 }
 
 .status-badge-success {
-  background: rgba(16, 185, 129, 0.15);
-  color: #6ee7b7;
-  border: 1px solid rgba(16, 185, 129, 0.3);
+  background: rgba(255, 20, 147, 0.18);
+  color: #FFB6E0;
+  border: 1px solid rgba(255, 20, 147, 0.35);
 }
 
 .status-badge-error {
@@ -670,33 +671,33 @@ input[aria-invalid="true"]:focus {
 }
 
 .status-badge-warning {
-  background: rgba(251, 191, 36, 0.15);
-  color: #fcd34d;
-  border: 1px solid rgba(251, 191, 36, 0.3);
+  background: rgba(255, 215, 0, 0.15);
+  color: #FFE066;
+  border: 1px solid rgba(255, 215, 0, 0.3);
 }
 
 .status-badge-info {
-  background: rgba(6, 182, 212, 0.15);
-  color: #67e8f9;
-  border: 1px solid rgba(6, 182, 212, 0.3);
+  background: rgba(255, 105, 180, 0.15);
+  color: #FFB6E0;
+  border: 1px solid rgba(255, 105, 180, 0.3);
 }
 
 .code-value {
   font-family: var(--font-mono);
   font-size: 0.875rem;
   color: var(--text-code);
-  background: rgba(99, 102, 241, 0.1);
+  background: rgba(255, 20, 147, 0.12);
   padding: 0.125rem 0.5rem;
   border-radius: 0.375rem;
-  border: 1px solid rgba(99, 102, 241, 0.2);
+  border: 1px solid rgba(255, 105, 180, 0.25);
 }
 
 /* === Collapsible Section === */
 .collapsible {
-  border: 1px solid rgba(99, 102, 241, 0.15);
+  border: 1px solid rgba(255, 20, 147, 0.18);
   border-radius: 0.75rem;
   overflow: hidden;
-  background: rgba(15, 23, 42, 0.3);
+  background: rgba(30, 5, 25, 0.35);
 }
 
 .collapsible-header {
@@ -716,7 +717,7 @@ input[aria-invalid="true"]:focus {
 }
 
 .collapsible-header:hover {
-  background: rgba(99, 102, 241, 0.05);
+  background: rgba(255, 20, 147, 0.07);
 }
 
 .collapsible-arrow {
@@ -746,8 +747,8 @@ input[aria-invalid="true"]:focus {
 
 /* === JSON Viewer === */
 .json-viewer {
-  background: rgba(10, 14, 26, 0.9);
-  border: 1px solid rgba(99, 102, 241, 0.2);
+  background: rgba(20, 0, 18, 0.92);
+  border: 1px solid rgba(255, 20, 147, 0.22);
   border-radius: 0.75rem;
   padding: 1.25rem;
   position: relative;
@@ -774,27 +775,27 @@ input[aria-invalid="true"]:focus {
 
 .json-viewer::-webkit-scrollbar-track,
 .json-viewer pre::-webkit-scrollbar-track {
-  background: rgba(99, 102, 241, 0.05);
+  background: rgba(255, 20, 147, 0.05);
   border-radius: 4px;
 }
 
 .json-viewer::-webkit-scrollbar-thumb,
 .json-viewer pre::-webkit-scrollbar-thumb {
-  background: rgba(99, 102, 241, 0.3);
+  background: rgba(255, 20, 147, 0.3);
   border-radius: 4px;
 }
 
 .json-viewer::-webkit-scrollbar-thumb:hover,
 .json-viewer pre::-webkit-scrollbar-thumb:hover {
-  background: rgba(99, 102, 241, 0.5);
+  background: rgba(255, 20, 147, 0.5);
 }
 
 /* JSON Syntax Highlighting */
-.json-key { color: #818cf8; font-weight: 500; }
-.json-string { color: #34d399; }
-.json-number { color: #fbbf24; }
-.json-boolean { color: #f472b6; }
-.json-null { color: #94a3b8; font-style: italic; }
+.json-key { color: #FF85C1; font-weight: 500; }
+.json-string { color: #FFD6EE; }
+.json-number { color: #FFD700; }
+.json-boolean { color: #FF69B4; }
+.json-null { color: #D490B8; font-style: italic; }
 
 /* === Copy Button === */
 .copy-btn {
@@ -805,8 +806,8 @@ input[aria-invalid="true"]:focus {
   align-items: center;
   gap: 0.375rem;
   padding: 0.375rem 0.75rem;
-  background: rgba(99, 102, 241, 0.15);
-  border: 1px solid rgba(99, 102, 241, 0.3);
+  background: rgba(255, 20, 147, 0.15);
+  border: 1px solid rgba(255, 20, 147, 0.35);
   border-radius: 0.5rem;
   color: var(--text-secondary);
   font-size: 0.6875rem;
@@ -820,21 +821,21 @@ input[aria-invalid="true"]:focus {
 }
 
 .copy-btn:hover {
-  background: rgba(99, 102, 241, 0.25);
+  background: rgba(255, 20, 147, 0.28);
   color: var(--text-primary);
-  border-color: rgba(99, 102, 241, 0.5);
+  border-color: rgba(255, 20, 147, 0.55);
   transform: translateY(-1px);
 }
 
 .copy-btn.copied {
-  background: rgba(16, 185, 129, 0.15);
-  border-color: rgba(16, 185, 129, 0.5);
+  background: rgba(255, 105, 180, 0.18);
+  border-color: rgba(255, 105, 180, 0.55);
   color: var(--accent-success);
 }
 
 /* === Error Detail Block === */
 .error-detail {
-  background: rgba(10, 14, 26, 0.9);
+  background: rgba(20, 0, 18, 0.92);
   border: 1px solid rgba(239, 68, 68, 0.2);
   border-radius: 0.75rem;
   padding: 1.25rem;
@@ -850,7 +851,7 @@ input[aria-invalid="true"]:focus {
 }
 
 .error-detail .detail-key {
-  color: #818cf8;
+  color: #FF85C1;
 }
 
 .error-detail .detail-string {
@@ -858,13 +859,13 @@ input[aria-invalid="true"]:focus {
 }
 
 .error-detail .detail-value {
-  color: #fcd34d;
+  color: #FFD700;
 }
 
 /* === Info Panel (legacy compat) === */
 .info-panel {
-  background: rgba(15, 23, 42, 0.5);
-  border: 1px solid rgba(99, 102, 241, 0.15);
+  background: rgba(30, 5, 25, 0.5);
+  border: 1px solid rgba(255, 20, 147, 0.18);
   border-radius: 1rem;
   padding: 1.5rem;
   margin-top: 1.5rem;
@@ -876,7 +877,7 @@ input[aria-invalid="true"]:focus {
   justify-content: space-between;
   align-items: center;
   padding: 0.75rem 0;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  border-bottom: 1px solid rgba(255, 105, 180, 0.12);
 }
 
 .info-row:last-child {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Duo Universal Prompt 2FA integration testing sandbox">
-    <meta name="theme-color" content="#0a0e1a">
+    <meta name="theme-color" content="#1a0020">
     <title>{% block title %}Duo 2FA Demo{% endblock %}</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔐</text></svg>">
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
The duo-auth testing sandbox was running a developer-focused dark navy theme with indigo/purple accents — functional, but visually generic. Anyone demoing or sharing a screenshot of the app had no visual personality to speak of, and the request came in to give the UI a Barbie-themed treatment.

The approach was a full CSS palette swap centered on a vivid hot pink background (`#C2005A`) with deep pink accents (`#FF1493`, `#FF69B4`), a white-tinted radial grid overlay, and dark-card contrast so form elements stay readable against the bright background. All color tokens in `:root` were replaced — backgrounds, card surfaces, borders, gradients, shadows, JSON syntax highlighting, badges, and hover states — so the theming is consistent top to bottom without touching any HTML structure or Python logic.

Users now see a bright, saturated Barbie-pink page behind a dark floating card, with hot pink buttons, pink-glowing labels, and gold warning accents for that extra Barbie glamour. The before/after contrast is dramatic: it went from near-black navy to full Barbie pink.

## Testing

Verified visually in browser at `http://localhost:8080` — login page, header, footer, banner, form inputs, and the CTA button all reflect the new palette. Captured before/after full-page screenshots confirming the change. All existing Flask routes and functionality remain untouched.

---

Requested by omara

Implemented by Claude Sonnet.

Code reviewed via Codex.
